### PR TITLE
Make NDVI band and image optional

### DIFF
--- a/pyveg/configs/config_liverpool_example.py
+++ b/pyveg/configs/config_liverpool_example.py
@@ -36,7 +36,7 @@ modules_to_use = {
 
 # The following demonstrates how parameters can be set for individual Modules or Sequences:
 special_config = {
-    "Sentinel2": {"time_per_point": "3m", "region_size": 0.1125,'ndvi':True
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.1125
 }     # this is a whole Sequence
            # and another Module
 }

--- a/pyveg/configs/config_liverpool_example.py
+++ b/pyveg/configs/config_liverpool_example.py
@@ -19,7 +19,7 @@ output_location_type = "local"
 
 coordinates = (-2.983333, 53.400002)
 
-date_range = ["2016-05-01", "2021-08-01"]
+date_range = ["2016-05-01", "2016-08-01"]
 
 # From the dictionary entries in data_collections.py, which shall we use
 # (these will become "Sequences")

--- a/pyveg/configs/config_liverpool_example.py
+++ b/pyveg/configs/config_liverpool_example.py
@@ -19,7 +19,7 @@ output_location_type = "local"
 
 coordinates = (-2.983333, 53.400002)
 
-date_range = ["2016-01-01", "2021-01-01"]
+date_range = ["2016-05-01", "2021-08-01"]
 
 # From the dictionary entries in data_collections.py, which shall we use
 # (these will become "Sequences")
@@ -36,7 +36,7 @@ modules_to_use = {
 
 # The following demonstrates how parameters can be set for individual Modules or Sequences:
 special_config = {
-    "Sentinel2": {"time_per_point": "1y", "region_size": 0.1125,
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.1125,'ndvi':True
 }     # this is a whole Sequence
            # and another Module
 }

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -53,6 +53,7 @@ class DownloaderModule(BaseModule):
             ("output_location", [str]),
             ("output_location_type", [str]),
             ("replace_existing_files", [bool]),
+            ("ndvi",[bool])
         ]
         return
 
@@ -73,6 +74,9 @@ class DownloaderModule(BaseModule):
             self.output_location_type = "local"
         if not "replace_existing_files" in vars(self):
             self.replace_existing_files = False
+        if not "ndvi" in vars(self):
+            self.ndvi = False
+
 
         return
 
@@ -264,10 +268,15 @@ class VegetationDownloader(DownloaderModule):
         dataset = apply_mask_cloud(dataset, self.collection_name, self.cloudy_pix_flag)
         # Take median
         image = dataset.median()
-        # Calculate NDVI
-        image = add_NDVI(image, self.RGB_bands[0], self.NIR_band)
-        # select only RGB + NDVI bands to download
-        bands_to_select = self.RGB_bands + ["NDVI"]
+
+        if self.ndvi:
+            # Calculate NDVI
+            image = add_NDVI(image, self.RGB_bands[0], self.NIR_band)
+            # select only RGB + NDVI bands to download
+            bands_to_select = self.RGB_bands + ["NDVI"]
+        else:
+            bands_to_select = self.RGB_bands
+
         image = image.select(bands_to_select)
         return [image]
 

--- a/pyveg/tests/test_download_modules.py
+++ b/pyveg/tests/test_download_modules.py
@@ -65,6 +65,7 @@ def test_veg_downloader_run_sentinel2():
     veg_downloader.cloudy_pix_frac = 50
     veg_downloader.cloudy_pix_flag = "CLOUDY_PIXEL_PERCENTAGE"
     veg_downloader.mask_cloud = True
+    veg_downloader.ndvi = True
     veg_downloader.output_location = os.path.join(TMPDIR, "testveg")
     veg_downloader.configure()
     veg_downloader.run()

--- a/pyveg/tests/test_processor_modules.py
+++ b/pyveg/tests/test_processor_modules.py
@@ -30,6 +30,7 @@ def test_Sentinel2_image_processor():
     vip = VegetationImageProcessor()
     vip.input_location = dir_path
     vip.output_location = tmp_png_path
+    vip.ndvi = True
     vip.coords = [11.58, 27.95]
     vip.configure()
     vip.run()


### PR DESCRIPTION
Fixes #3 

Adds NDVI attribute to downloader and processor modules and set is as false for default. Now only RGB images get created and split.