### PR TITLE
Pixel level metadata on image counts

### DIFF
--- a/pyveg/configs/collections.py
+++ b/pyveg/configs/collections.py
@@ -10,7 +10,7 @@ data_collections = {
         "cloudy_pix_frac": 50,
         "cloudy_pix_flag": "CLOUDY_PIXEL_PERCENTAGE",
         "min_date": "2016-01-01",
-        "max_date": "2022-01-01",  # For 2020 paper, look at four whole years
+        "max_date": "2022-01-01",  # Get to current year.
 #        "max_date": time.strftime("%Y-%m-%d"),
         "time_per_point": "1m",
     },

--- a/pyveg/configs/collections.py
+++ b/pyveg/configs/collections.py
@@ -10,7 +10,7 @@ data_collections = {
         "cloudy_pix_frac": 50,
         "cloudy_pix_flag": "CLOUDY_PIXEL_PERCENTAGE",
         "min_date": "2016-01-01",
-        "max_date": "2020-01-01",  # For 2020 paper, look at four whole years
+        "max_date": "2022-01-01",  # For 2020 paper, look at four whole years
 #        "max_date": time.strftime("%Y-%m-%d"),
         "time_per_point": "1m",
     },

--- a/pyveg/configs/config_birmingham_example.py
+++ b/pyveg/configs/config_birmingham_example.py
@@ -1,0 +1,44 @@
+from pyveg.coordinates import coordinate_store
+from pyveg.configs.collections import data_collections
+
+name = "birmingham"
+
+# Define location to save all outputs
+output_location = "birmingham-test"
+
+#output_location_type = "azure"
+output_location_type = "local"
+
+# parse selection. Note (long, lat) GEE convention.
+#entry = coordinate_store.loc[coordinate_id]
+# modify this line to set coords based on entries in `coordinates.py`
+#coordinate_id = "00"
+
+# parse selection. Note (long, lat) GEE convention.
+#entry = coordinate_store.loc[coordinate_id]
+#coordinates = (entry.longitude, entry.latitude)
+
+coordinates = (-1.898575, 52.489471)
+
+date_range = ["2020-05-01", "2020-08-01"]
+
+# From the dictionary entries in data_collections.py, which shall we use
+# (these will become "Sequences")
+collections_to_use = ["Sentinel2"]
+
+# Dictionary defining what Modules should run in each Sequence.
+
+modules_to_use = {
+    "Sentinel2": [
+        "VegetationDownloader",
+        "VegetationImageProcessor",
+    ],
+}
+
+# The following demonstrates how parameters can be set for individual Modules or Sequences:
+special_config = {
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.10,
+
+}     # this is a whole Sequence
+           # and another Module
+}

--- a/pyveg/configs/config_leicester_example.py
+++ b/pyveg/configs/config_leicester_example.py
@@ -1,0 +1,43 @@
+from pyveg.coordinates import coordinate_store
+from pyveg.configs.collections import data_collections
+
+name = "leicester"
+
+# Define location to save all outputs
+output_location = "leicester-test"
+
+#output_location_type = "azure"
+output_location_type = "local"
+
+# parse selection. Note (long, lat) GEE convention.
+#entry = coordinate_store.loc[coordinate_id]
+# modify this line to set coords based on entries in `coordinates.py`
+#coordinate_id = "00"
+
+# parse selection. Note (long, lat) GEE convention.
+#entry = coordinate_store.loc[coordinate_id]
+#coordinates = (entry.longitude, entry.latitude)
+
+coordinates = (-1.133333, 52.633331)
+date_range = ["2020-05-01", "2020-08-01"]
+
+# From the dictionary entries in data_collections.py, which shall we use
+# (these will become "Sequences")
+collections_to_use = ["Sentinel2"]
+
+# Dictionary defining what Modules should run in each Sequence.
+
+modules_to_use = {
+    "Sentinel2": [
+        "VegetationDownloader",
+        "VegetationImageProcessor",
+    ],
+}
+
+# The following demonstrates how parameters can be set for individual Modules or Sequences:
+special_config = {
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.10,
+
+}     # this is a whole Sequence
+           # and another Module
+}

--- a/pyveg/configs/config_liverpool_example.py
+++ b/pyveg/configs/config_liverpool_example.py
@@ -36,7 +36,7 @@ modules_to_use = {
 
 # The following demonstrates how parameters can be set for individual Modules or Sequences:
 special_config = {
-    "Sentinel2": {"time_per_point": "3m", "region_size": 0.1125
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.10
 }     # this is a whole Sequence
            # and another Module
 }

--- a/pyveg/configs/config_london_example.py
+++ b/pyveg/configs/config_london_example.py
@@ -1,0 +1,30 @@
+from pyveg.coordinates import coordinate_store
+from pyveg.configs.collections import data_collections
+
+#Name of job
+name = "london"
+
+# Define location to save all outputs
+output_location = "london-test"
+output_location_type = "local"
+
+coordinates = (0.0029564, 51.4825565)
+
+date_range = ["2017-05-01", "2017-09-01"]
+
+# From the dictionary entries in data_collections.py, which shall we use
+# (these will become "Sequences")
+collections_to_use = ["Sentinel2"]
+
+# Dictionary defining what Modules should run in each Sequence.
+modules_to_use = {
+    "Sentinel2": [
+        "VegetationDownloader",
+        "VegetationImageProcessor",
+    ],
+}
+
+# The following demonstrates how parameters can be set for individual Modules or Sequences:
+special_config = {
+    "Sentinel2": {"time_per_point": "3m", "region_size": 0.10}
+}

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -24,7 +24,7 @@ from pyveg.src.date_utils import (
 )
 from pyveg.src.file_utils import download_and_unzip
 from pyveg.src.coordinate_utils import get_region_string
-from pyveg.src.gee_interface import apply_mask_cloud, add_NDVI, add_count_mosaic
+from pyveg.src.gee_interface import apply_mask_cloud, add_NDVI
 
 from pyveg.src.pyveg_pipeline import BaseModule, logger
 
@@ -285,11 +285,11 @@ class VegetationDownloader(DownloaderModule):
             # create pixel level count image
             count = dataset.count()
             # sum counts on each band into one image
-            image_count = add_count_mosaic(count, self.RGB_bands)
+            image_count = count.select(self.RGB_bands[0]).rename("COUNT")
             # add count image as a band
             image = image.addBands(image_count)
 
-            bands_to_select = bands_to_select+ ['COUNT']
+            bands_to_select = bands_to_select + ['COUNT']
 
         # select relevant bands
         image = image.select(bands_to_select)

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -268,6 +268,8 @@ class VegetationDownloader(DownloaderModule):
         dataset = apply_mask_cloud(dataset, self.collection_name, self.cloudy_pix_flag)
         # Take median
         image = dataset.median()
+        count = dataset.count()
+
 
         if self.ndvi:
             # Calculate NDVI
@@ -277,7 +279,11 @@ class VegetationDownloader(DownloaderModule):
         else:
             bands_to_select = self.RGB_bands
 
-        image = image.select(bands_to_select)
+        mosaic = count.select(self.RGB_bands[0]).add(count.select(self.RGB_bands[1]))\
+            .add(count.select(self.RGB_bands[2])).rename('mosaic')
+
+        image = ee.Image(image).addBands(mosaic)
+        image = image.select(bands_to_select + ['mosaic'])
         return [image]
 
 

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -226,8 +226,9 @@ class DownloaderModule(BaseModule):
 class VegetationDownloader(DownloaderModule):
     """
     Specialization of the DownloaderModule class, to deal with
-    imagery from Sentinel 2 or Landsat 5-8 satellites, and
-    get NDVI band from combining red and near-infra-red.
+    imagery from Sentinel 2 or Landsat 5-8 satellites,
+    get NDVI band from combining red and near-infra-red and create a
+    COUNT band with number of images per pixel in the composite.
     """
 
     def __init__(self, name=None):
@@ -255,7 +256,8 @@ class VegetationDownloader(DownloaderModule):
     def prep_images(self, dataset):
         """
         Take a dataset that has already been filtered by date and location.
-        Then apply specific filters, take the median, and calculate NDVI.
+        Then apply specific filters, take the median, and calculate NDVI and create
+        the COUNT band.
 
         Parameters
         ----------

--- a/pyveg/src/gee_interface.py
+++ b/pyveg/src/gee_interface.py
@@ -90,16 +90,6 @@ def add_NDVI(image, red_band, near_infrared_band):
         print("Something went wrong in the NDVI variable construction")
         return image
 
-def add_count_mosaic(image, RGB_bands):
-    try:
-        image_count = image.select(RGB_bands[0]).add(image.select(RGB_bands[1])) \
-            .add(image.select(RGB_bands[2])).rename("COUNT")
-        return image_count
-    except:
-        print("Something went wrong in the COUNT variable construction")
-        return image
-
-
 def ee_prep_data(
     collection_dict, coords, date_range, region_size=0.1, scale=10, mask_cloud=True
 ):

--- a/pyveg/src/gee_interface.py
+++ b/pyveg/src/gee_interface.py
@@ -90,6 +90,15 @@ def add_NDVI(image, red_band, near_infrared_band):
         print("Something went wrong in the NDVI variable construction")
         return image
 
+def add_count_mosaic(image, RGB_bands):
+    try:
+        image_count = image.select(RGB_bands[0]).add(image.select(RGB_bands[1])) \
+            .add(image.select(RGB_bands[2])).rename("COUNT")
+        return image_count
+    except:
+        print("Something went wrong in the COUNT variable construction")
+        return image
+
 
 def ee_prep_data(
     collection_dict, coords, date_range, region_size=0.1, scale=10, mask_cloud=True

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -169,6 +169,36 @@ def scale_tif(input_filename):
             )
     return new_img
 
+def create_count_heatmap(input_filename):
+    """
+    Given only a single band, get a heatmap based on the raw values
+
+    Parameters
+    ==========
+    input_filename: str, location of input image
+
+    Returns
+    =======
+    new_img: pillow Image.
+
+    """
+
+    pix = cv.imread(input_filename, cv.IMREAD_ANYDEPTH)
+
+    print (pix.max())
+    print (pix.min())
+
+    image_plt = plt.matshow(pix)
+    plt.colorbar()
+
+    scaled_img = (image_plt.get_array() - image_plt.get_clim()[0]) / (image_plt.get_clim()[1] - image_plt.get_clim()[0])
+    new_image = Image.fromarray(np.uint8(image_plt.get_cmap()(scaled_img) * 255))
+
+    #f, ax = plt.subplot()
+    #ax.matshow(pix)
+    #f.colorbar(f,ax=ax)
+
+    return new_image
 
 def convert_to_rgb(band_dict):
     """

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -185,19 +185,9 @@ def create_count_heatmap(input_filename):
 
     pix = cv.imread(input_filename, cv.IMREAD_ANYDEPTH)
 
-    print (pix.max())
-    print (pix.min())
-
     image_plt = plt.matshow(pix)
-    plt.colorbar()
-
     scaled_img = (image_plt.get_array() - image_plt.get_clim()[0]) / (image_plt.get_clim()[1] - image_plt.get_clim()[0])
     new_image = Image.fromarray(np.uint8(image_plt.get_cmap()(scaled_img) * 255))
-
-    #f, ax = plt.subplot()
-    #ax.matshow(pix)
-    #f.colorbar(f,ax=ax)
-
     return new_image
 
 def convert_to_rgb(band_dict):

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -442,10 +442,14 @@ class VegetationImageProcessor(ProcessorModule):
     1) Full-size RGB image
     2) Many 50x50 pixel sub-images of RGB image
 
-    Optional outputs can be (if ndvi flag is true):
+    Optional outputs can be
+    (if ndvi flag is true):
     3) Full-size NDVI image (greyscale)
     4) Full-size black+white NDVI image (after processing, thresholding, ...)
     5) Many 50x50 pixel sub-images of black+white NDVI image.
+    (if count flag is true):
+    6) Full-size COUNT image (heatmap)
+    7) Many NxN pixel sub-images of the COUNT image.
 
     """
 
@@ -676,7 +680,7 @@ class VegetationImageProcessor(ProcessorModule):
             )
 
         if self.count:
-            # save the NDVI image
+            # save the COUNT image
             count_tif = self.get_file(
                self.join_path(input_filepath, "download.COUNT.tif"), self.input_location_type
             )

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -471,6 +471,8 @@ class VegetationImageProcessor(ProcessorModule):
             self.split_RGB_images = True
         if not "ndvi" in vars(self):
             self.ndvi = False
+        if not "count" in vars(self):
+            self.count = True
         # in PROCESSED dir we expect RGB. NDVI, BWNDVI
         self.num_files_per_point = 3
         self.input_location_subdirs = ["RAW"]
@@ -671,6 +673,24 @@ class VegetationImageProcessor(ProcessorModule):
             self.split_and_save_sub_images(
                 processed_ndvi, date_string, coords_string, "BWNDVI"
             )
+
+        if self.count:
+            # save the NDVI image
+            count_tif = self.get_file(
+               self.join_path(input_filepath, "download.COUNT.tif"), self.input_location_type
+            )
+            count_image = scale_tif(count_tif)
+            count_filepath = self.construct_image_savepath(
+                date_string, coords_string, "COUNT"
+            )
+            self.save_image(
+                count_image, os.path.dirname(count_filepath), os.path.basename(count_filepath)
+            )
+
+            # split and save sub-images
+            self.split_and_save_sub_images(count_image, date_string, coords_string, "COUNT")
+
+
 
         return True
 

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -23,7 +23,8 @@ from pyveg.src.image_utils import (
     crop_image_npix,
     scale_tif,
     process_and_threshold,
-    pillow_to_numpy
+    pillow_to_numpy,
+    create_count_heatmap
 )
 from pyveg.src.file_utils import (
     save_image,
@@ -679,7 +680,8 @@ class VegetationImageProcessor(ProcessorModule):
             count_tif = self.get_file(
                self.join_path(input_filepath, "download.COUNT.tif"), self.input_location_type
             )
-            count_image = scale_tif(count_tif)
+
+            count_image = create_count_heatmap(count_tif)
             count_filepath = self.construct_image_savepath(
                 date_string, coords_string, "COUNT"
             )

--- a/pyveg/tests/test_download_modules.py
+++ b/pyveg/tests/test_download_modules.py
@@ -66,6 +66,7 @@ def test_veg_downloader_run_sentinel2():
     veg_downloader.cloudy_pix_flag = "CLOUDY_PIXEL_PERCENTAGE"
     veg_downloader.mask_cloud = True
     veg_downloader.ndvi = True
+    veg_downloader.count = False
     veg_downloader.output_location = os.path.join(TMPDIR, "testveg")
     veg_downloader.configure()
     veg_downloader.run()


### PR DESCRIPTION
Fixes #9 

Adding an option to download an extra band with image counts at the pixel level. Changes:

- [x] Adds a "count" option in the same way as the "ndvi" to the Downloader Module: This option gets counts of images by pixel for each band (B2, B3, B4) and adds them into a single band called "COUNTS". If this flag is true, the pipeline downloads the 3 RGB bands plus a COUNT band and saves it as a tiff file.
- [x]  Adds a "count" option in the same way as the "ndvi" to the Processor Module: If this flag is true, the pipeline turns the dowloaded "COUNT" tiff file into a heatmap png image, and splits it into sub-images as it is done with the RGB images.
- [x] Add a London config file example.
- [x] Increases the date limit for downloading in the general config file (we had a limit of 2020 in the pyveg paper).
- [x] Reduces the default region size, given that we are downloading an extra band. 